### PR TITLE
fix nits

### DIFF
--- a/pkgs/tools/package-management/lix/common.nix
+++ b/pkgs/tools/package-management/lix/common.nix
@@ -233,14 +233,20 @@ stdenv.mkDerivation {
   '';
 
   doCheck = true;
-  mesonCheckFlags = [ "--suite=check" "--print-errorlogs" ];
+  mesonCheckFlags = [
+    "--suite=check"
+    "--print-errorlogs"
+  ];
   checkInputs = [
     gtest
     rapidcheck
   ];
 
   doInstallCheck = true;
-  mesonInstallCheckFlags = [ "--suite=installcheck" "--print-errorlogs" ];
+  mesonInstallCheckFlags = [
+    "--suite=installcheck"
+    "--print-errorlogs"
+  ];
 
   preInstallCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
     # socket path becomes too long otherwise

--- a/pkgs/tools/package-management/lix/common.nix
+++ b/pkgs/tools/package-management/lix/common.nix
@@ -78,7 +78,7 @@ assert (hash == null) -> (src != null);
 assert lib.assertMsg (docCargoHash != null || docCargoLock != null)
   "Either `lix-doc`'s cargoHash using `docCargoHash` or `lix-doc`'s `cargoLock.lockFile` using `docCargoLock` must be set!";
 let
-  isLegacyParser = builtins.compareVersions version "2.91" < 0;
+  isLegacyParser = lib.versionOlder version "2.91";
 in
 stdenv.mkDerivation {
   pname = "lix";

--- a/pkgs/tools/package-management/lix/common.nix
+++ b/pkgs/tools/package-management/lix/common.nix
@@ -19,7 +19,6 @@ assert (hash == null) -> (src != null);
 {
   stdenv,
   meson,
-  bash,
   bison,
   boehmgc,
   boost,
@@ -27,29 +26,20 @@ assert (hash == null) -> (src != null);
   busybox-sandbox-shell,
   bzip2,
   callPackage,
-  coreutils,
   curl,
   cmake,
-  docbook_xsl_ns,
-  docbook5,
   doxygen,
   editline,
   flex,
   git,
-  gnutar,
   gtest,
-  gzip,
   jq,
   lib,
   libarchive,
   libcpuid,
-  libgit2,
   libsodium,
-  libxml2,
-  libxslt,
   lowdown,
   lsof,
-  man,
   mercurial,
   mdbook,
   mdbook-linkcheck,
@@ -58,7 +48,6 @@ assert (hash == null) -> (src != null);
   openssl,
   toml11,
   pegtl,
-  perl,
   python3,
   pkg-config,
   rapidcheck,
@@ -129,7 +118,7 @@ stdenv.mkDerivation {
       lsof
     ]
     ++ lib.optionals isLegacyParser [ bison ]
-    ++ lib.optionals (enableDocumentation) [
+    ++ lib.optionals enableDocumentation [
       (lib.getBin lowdown)
       mdbook
       mdbook-linkcheck
@@ -284,7 +273,7 @@ stdenv.mkDerivation {
   # point 'nix edit' and ofborg at the file that defines the attribute,
   # not this common file.
   pos = builtins.unsafeGetAttrPos "version" args;
-  meta = with lib; {
+  meta = {
     description = "Powerful package manager that makes package management reliable and reproducible";
     longDescription = ''
       Lix (a fork of Nix) is a powerful package manager for Linux and other Unix systems that
@@ -294,10 +283,10 @@ stdenv.mkDerivation {
       environments.
     '';
     homepage = "https://lix.systems";
-    license = licenses.lgpl21Plus;
+    license = lib.licenses.lgpl21Plus;
     inherit maintainers;
-    platforms = platforms.unix;
-    outputsToInstall = [ "out" ] ++ optional enableDocumentation "man";
+    platforms = lib.platforms.unix;
+    outputsToInstall = [ "out" ] ++ lib.optional enableDocumentation "man";
     mainProgram = "nix";
     broken = enableStatic;
   };

--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -34,7 +34,7 @@ let
       };
 
   # Since Lix 2.91 does not use boost coroutines, it does not need boehmgc patches either.
-  needsBoehmgcPatches = version: builtins.compareVersions version "2.91" < 0;
+  needsBoehmgcPatches = version: lib.versionOlder version "2.91";
 
   common =
     args:

--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -49,7 +49,7 @@ let
       aws-sdk-cpp = aws-sdk-cpp-nix;
     };
 in
-lib.makeExtensible (self: ({
+lib.makeExtensible (self: {
   buildLix = common;
 
   lix_2_90 = (
@@ -70,4 +70,4 @@ lib.makeExtensible (self: ({
 
   latest = self.lix_2_91;
   stable = self.lix_2_91;
-}))
+})


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
